### PR TITLE
Refactor: 분산된 로그인 검증 로직을 AOP로 분리하여 서비스 로직 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/flab/mars/annotation/AccessTokenCheck.java
+++ b/src/main/java/com/flab/mars/annotation/AccessTokenCheck.java
@@ -1,0 +1,11 @@
+package com.flab.mars.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD})
+public @interface AccessTokenCheck {
+}

--- a/src/main/java/com/flab/mars/annotation/LoginCheck.java
+++ b/src/main/java/com/flab/mars/annotation/LoginCheck.java
@@ -1,0 +1,11 @@
+package com.flab.mars.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD})
+public @interface LoginCheck {
+}

--- a/src/main/java/com/flab/mars/aop/LoginAspect.java
+++ b/src/main/java/com/flab/mars/aop/LoginAspect.java
@@ -1,0 +1,66 @@
+package com.flab.mars.aop;
+
+import com.flab.mars.domain.vo.MemberInfoVO;
+import com.flab.mars.exception.AuthException;
+import com.flab.mars.support.SessionUtil;
+import jakarta.servlet.http.HttpSession;
+import lombok.extern.log4j.Log4j2;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+/**
+ *  @Aspect : 공통적인 기능을 Aspect 로 사용하겠다고 명시하는 어노테이션
+ *  @Component : 스프링 컨테이너에 빈 등록
+ */
+@Aspect
+@Component
+@Log4j2
+public class LoginAspect {
+
+    /**
+     * @Before : 해당 Aspect 어노테이션이 메서드가 실행되기 전 Interceptor 와 같이 동작
+     * @annotation : 결합점의 대상 객체가 주어진 어노테이션을 갖는 결합점
+     * @param joinPoint
+     */
+    @Before("@annotation(com.flab.mars.annotation.LoginCheck)")
+    public void loginCheck(JoinPoint joinPoint) {
+        log.debug(" AOP - LoginCheck");
+
+        //스프링에서 HttpSession 객체 가져오기
+        checkSession();
+
+    }
+
+    @Before("@annotation(com.flab.mars.annotation.AccessTokenCheck)")
+    public void accessTokenCheck(JoinPoint joinPoint) {
+
+        log.debug(" AOP - accessTokenCheck");
+
+        //스프링에서 HttpSession 객체 가져오기
+        MemberInfoVO sessionLoginUser = checkSession();
+
+        if(sessionLoginUser.getAccessToken() == null) {
+            throw new AuthException("로그인에 실패했습니다. ACCESS 토큰을 가져올 수 없습니다.");
+        }
+
+    }
+
+    private MemberInfoVO checkSession() {
+        HttpSession session = ((ServletRequestAttributes) (RequestContextHolder.currentRequestAttributes())).getRequest().getSession(false);
+
+        if (session == null) {
+            throw new AuthException("세션이 존재하지 않습니다. 다시 로그인해주세요.");
+        }
+
+        MemberInfoVO loginUser = SessionUtil.getSessionLoginUser(session);
+        if(loginUser == null ) {
+            throw new AuthException("세션이 만료되었습니다. 다시 로그인해주세요.");
+        }
+
+        return loginUser;
+    }
+}


### PR DESCRIPTION
- 세션 체크 및 로그인 검증 로직을 LoginAspect로 이동
- @LoginCheck 및 @AccessTokenCheck 어노테이션을 사용하여 AOP 적용
- 서비스 로직에서 로그인 관련 코드 제거 및 비즈니스 로직 집중
- 코드 중복 제거 및 유지 보수성 향상
Close #26 