### PR TITLE
feature: WebClient 연결 타임아웃 처리 및 연결 오류 핸들링

### DIFF
--- a/src/main/java/com/flab/mars/config/RootConfig.java
+++ b/src/main/java/com/flab/mars/config/RootConfig.java
@@ -1,9 +1,12 @@
 package com.flab.mars.config;
 
 import com.flab.mars.client.KISApiUrls;
+import io.netty.channel.ChannelOption;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
 
 @Configuration
 public class RootConfig {
@@ -12,6 +15,11 @@ public class RootConfig {
     public WebClient webClient(WebClient.Builder builder) {
         return builder.baseUrl(KISApiUrls.BASE_URL) // KIS API의 기본 URL 설정
                 .defaultHeader("content-type", "application/json; charset=utf-8") // 기본 헤더 설정
+                .clientConnector(new ReactorClientHttpConnector(
+                        HttpClient.create()
+                                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 5000)// 연결 타임아웃 5초
+                                .option(ChannelOption.SO_TIMEOUT, 10) // 소켓 타임 아웃
+                ))
                 .build();
     }
 }

--- a/src/main/java/com/flab/mars/config/RootConfig.java
+++ b/src/main/java/com/flab/mars/config/RootConfig.java
@@ -2,11 +2,16 @@ package com.flab.mars.config;
 
 import com.flab.mars.client.KISApiUrls;
 import io.netty.channel.ChannelOption;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import io.netty.handler.timeout.WriteTimeoutHandler;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.netty.http.client.HttpClient;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 
 @Configuration
 public class RootConfig {
@@ -17,8 +22,12 @@ public class RootConfig {
                 .defaultHeader("content-type", "application/json; charset=utf-8") // 기본 헤더 설정
                 .clientConnector(new ReactorClientHttpConnector(
                         HttpClient.create()
-                                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 5000)// 연결 타임아웃 5초
-                                .option(ChannelOption.SO_TIMEOUT, 10) // 소켓 타임 아웃
+                                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 5000) // 연결 타임아웃 5초
+                                .doOnConnected(conn -> conn
+                                        .addHandlerLast(new ReadTimeoutHandler(10, TimeUnit.SECONDS))
+                                        .addHandlerLast(new WriteTimeoutHandler(10))
+                                )
+                                .responseTimeout(Duration.ofSeconds(10)) // 응답 타임아웃 10초 추가
                 ))
                 .build();
     }

--- a/src/main/java/com/flab/mars/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/flab/mars/exception/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -14,5 +15,12 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ResultAPIDto<Object>> authException(AuthException e) {
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                 .body(ResultAPIDto.res(HttpStatus.UNAUTHORIZED, e.getMessage(), null));
+    }
+
+    @ExceptionHandler(WebClientRequestException.class)
+    private ResponseEntity<ResultAPIDto<String>> connectTimeoutException1(WebClientRequestException e) {
+        String errorMessage = e.getMessage() != null ? e.getMessage() : "Unexpected error occurred.";
+        return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+                .body(ResultAPIDto.res(HttpStatus.SERVICE_UNAVAILABLE, errorMessage, "연결 중 에러가 발생하였습니다."));
     }
 }

--- a/src/main/java/com/flab/mars/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/flab/mars/exception/GlobalExceptionHandler.java
@@ -12,7 +12,7 @@ public class GlobalExceptionHandler {
 
     // AuthException 예외 처리 메서드
     @ExceptionHandler(AuthException.class)
-    public ResponseEntity<ResultAPIDto<Object>> authException(AuthException e) {
+    private ResponseEntity<ResultAPIDto<Object>> authException(AuthException e) {
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                 .body(ResultAPIDto.res(HttpStatus.UNAUTHORIZED, e.getMessage(), null));
     }


### PR DESCRIPTION
- 외부 API 호출 시 연결 타임아웃과 소켓 타임아웃 시간을 단축하여 과도한 스레드 생성 방지
- 연결 실패 시 사용자에게 "연결 중 에러가 발생하였습니다." 메시지를 반환하여 오류 원인 제공
Close #35 