### PR TITLE
전역 예외 처리 핸들러 접근 제어자 변경

### DIFF
--- a/src/main/java/com/flab/mars/exception/AuthException.java
+++ b/src/main/java/com/flab/mars/exception/AuthException.java
@@ -1,5 +1,9 @@
 package com.flab.mars.exception;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.UNAUTHORIZED)
 public class AuthException extends RuntimeException {
     public AuthException(String message) {
         super(message);

--- a/src/main/java/com/flab/mars/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/flab/mars/exception/GlobalExceptionHandler.java
@@ -1,26 +1,37 @@
 package com.flab.mars.exception;
 
 import com.flab.mars.api.dto.response.ResultAPIDto;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.reactive.function.client.WebClientRequestException;
 
+@Slf4j // Lombok 의 @Slf4j 어노테이션을 사용하여 로그  객체 자동 생성
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
     // AuthException 예외 처리 메서드
     @ExceptionHandler(AuthException.class)
-    private ResponseEntity<ResultAPIDto<Object>> authException(AuthException e) {
+    public ResponseEntity<ResultAPIDto<Object>> authException(AuthException e) {
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                 .body(ResultAPIDto.res(HttpStatus.UNAUTHORIZED, e.getMessage(), null));
     }
 
     @ExceptionHandler(WebClientRequestException.class)
-    private ResponseEntity<ResultAPIDto<String>> connectTimeoutException1(WebClientRequestException e) {
+    public ResponseEntity<ResultAPIDto<String>> connectTimeoutException(WebClientRequestException e) {
         String errorMessage = e.getMessage() != null ? e.getMessage() : "Unexpected error occurred.";
         return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
                 .body(ResultAPIDto.res(HttpStatus.SERVICE_UNAVAILABLE, errorMessage, "연결 중 에러가 발생하였습니다."));
+    }
+
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<ResultAPIDto<Object>> runtimeException(RuntimeException e) {
+
+        log.error("Unexpected runtime exception occurred", e);
+        String errorMessage = e.getMessage() != null ? e.getMessage() : "Unexpected runtime error occurred.";
+        return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+                .body(ResultAPIDto.res(HttpStatus.SERVICE_UNAVAILABLE, errorMessage, "서버에서 예기치 않은 오류가 발생하였습니다."));
     }
 }


### PR DESCRIPTION
- @ExceptionHandler 메서드의 접근 제어자를 public으로 변경하여 Spring 표준 방식(공식 문서 및 샘플 코드 준수)에 맞춤
- 전역 예외 처리를 한 곳에서 집중 관리하여 코드 유지보수성과 일관성을 향상시킴

주요 변경 사항:

- AuthException 처리:
  - 발생 시 401 Unauthorized 상태 코드와 함께 예외 메시지를 반환합니다.
- WebClientRequestException 처리:
  - 발생 시 503 Service Unavailable 상태 코드와 함께 "연결 중 에러가 발생하였습니다."라는 메시지를 반환합니다.
- RuntimeException 처리:
  - 발생 시 503 Service Unavailable 상태 코드와 함께 "서버에서 예기치 않은 오류가 발생하였습니다." 메시지를 반환하며, 로그에 상세 예외 정보를 기록합니다.
Close #29 