### PR TITLE
FCM 기반 관심 주식 변동 알림 기능 추가  

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-cache'
 	implementation 'com.github.ben-manes.caffeine:caffeine:3.2.0'
 	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310' // LocalDateTime 직렬화 기능 추가
-
+	implementation 'com.google.firebase:firebase-admin:9.2.0' // FCM
 
 
 	compileOnly 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
 	implementation 'com.github.ben-manes.caffeine:caffeine:3.2.0'
 	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310' // LocalDateTime 직렬화 기능 추가
 	implementation 'com.google.firebase:firebase-admin:9.2.0' // FCM
+	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 
 
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/flab/mars/api/controller/FCMTokenContoller.java
+++ b/src/main/java/com/flab/mars/api/controller/FCMTokenContoller.java
@@ -1,0 +1,21 @@
+package com.flab.mars.api.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+/**
+ * FCM 알림기  각 기기에 맞는 토큰 생성 필수 (임시 코드)
+ */
+@RequiredArgsConstructor
+@Controller
+@RequestMapping("/api/fcmtoken")
+public class FCMTokenContoller {
+
+    @GetMapping
+    public String fcmToken() {
+        return "fcmtoken";
+    }
+
+}

--- a/src/main/java/com/flab/mars/api/dto/response/InterestStockDto.java
+++ b/src/main/java/com/flab/mars/api/dto/response/InterestStockDto.java
@@ -12,6 +12,6 @@ public class InterestStockDto {
     private String stockCode;
     private String curPrice;
     private String priceChange; // 전일 대비 가격 변화
-    private String priceChangeRate; // 전일 대비 변화률(%)
+    private Double priceChangeRate; // 전일 대비 변화률(%)
 
 }

--- a/src/main/java/com/flab/mars/client/dto/KisStockPriceDto.java
+++ b/src/main/java/com/flab/mars/client/dto/KisStockPriceDto.java
@@ -34,7 +34,7 @@ public class KisStockPriceDto {
         private String priceChangeSign; // 전일 대비 부호
 
         @JsonProperty("prdy_ctrt")
-        private String priceChangeRate; // 전일 대비율
+        private Double priceChangeRate; // 전일 대비율
 
         @JsonProperty("acml_tr_pbmn")
         private String accumulatedTradeAmount; // 누적 거래 대금

--- a/src/main/java/com/flab/mars/config/FCMConfig.java
+++ b/src/main/java/com/flab/mars/config/FCMConfig.java
@@ -1,0 +1,56 @@
+package com.flab.mars.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.messaging.FirebaseMessaging;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+/**
+ * firebase 는 firebase 서비스에 접근하기 위해 서비스 계정 인증이 필요함.
+ * 인증 정보를 로드하여 firebase 와 통신
+ */
+@Slf4j
+@Configuration
+public class FCMConfig {
+
+    @Value("${firebase.credentials.path}")
+    private String fileResourceURL;
+
+    @Bean
+    public FirebaseApp firebaseApp() throws IOException {
+        // Firebase 서비스 계정 키 파일 로드
+        ClassPathResource resource = new ClassPathResource(fileResourceURL);
+
+        // try-with-resources 사용으로 InputStream을 자동으로 닫음
+        try (InputStream serviceAccount = resource.getInputStream()) {
+            // FireBase 인증 옵션
+            FirebaseOptions options = FirebaseOptions.builder()
+                    .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                    .build();
+
+            // 현재 등록된 FirebaseApp  목록 가져오기
+            List<FirebaseApp> apps = FirebaseApp.getApps();
+
+            // 아직 초기화 되어이지 않다면 새로 생성
+            if (apps.isEmpty()) {
+                return FirebaseApp.initializeApp(options);
+            } else {
+                return apps.getFirst(); // 이미 초기화된 FirebaseApp 반환
+            }
+        }
+    }
+
+    @Bean
+    public FirebaseMessaging firebaseMessaging(FirebaseApp firebaseApp) {
+        return FirebaseMessaging.getInstance(firebaseApp);
+    }
+}

--- a/src/main/java/com/flab/mars/db/entity/InterestStockEntity.java
+++ b/src/main/java/com/flab/mars/db/entity/InterestStockEntity.java
@@ -16,7 +16,7 @@ public class InterestStockEntity {
     @Column (name = "interest_stock_id")
     private Long id; // 관심 주식의 고유 ID
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "stock_info_id")
     private StockInfoEntity stockInfo;
 

--- a/src/main/java/com/flab/mars/db/entity/MemberEntity.java
+++ b/src/main/java/com/flab/mars/db/entity/MemberEntity.java
@@ -33,6 +33,8 @@ public class MemberEntity {
 
     private LocalDateTime joinTime;
 
+    @Column(name = "fcm_token")
+    private String FCMToken;
 
 
     public MemberEntity(String name, String email, String pw ) {
@@ -45,6 +47,13 @@ public class MemberEntity {
     public MemberEntity updateMember(String name, String pw, PasswordEncoder passwordEncoder ){
         if(StringUtils.hasText(name)) this.name = name;
         if(StringUtils.hasText(pw)) this.pw = passwordEncoder.encode(pw);
+        return this;
+    }
+
+    public MemberEntity upsertFCMToken(String fcmToken) {
+        if (StringUtils.hasText(fcmToken)) {
+            this.FCMToken = fcmToken; // FCM 토큰을 신규로 설정하거나 기존 값을 갱신
+        }
         return this;
     }
 }

--- a/src/main/java/com/flab/mars/db/entity/PriceDataEntity.java
+++ b/src/main/java/com/flab/mars/db/entity/PriceDataEntity.java
@@ -37,7 +37,7 @@ public class PriceDataEntity {
 
     private String priceChange; // 전일 대비
     private String priceChangeSign; // 전일 대비 부호 1 : 상한,  2 : 상승, 3 : 보합 ,4 : 하한,  5 : 하락
-    private String priceChangeRate; // 전일 대비율
+    private Double  priceChangeRate; // 전일 대비율
 
     private LocalDateTime dateTime; // 데이터 발생 시간 (날짜+시간)
 

--- a/src/main/java/com/flab/mars/db/repository/InterestStockRepository.java
+++ b/src/main/java/com/flab/mars/db/repository/InterestStockRepository.java
@@ -12,4 +12,5 @@ public interface InterestStockRepository extends JpaRepository<InterestStockEnti
 
     List<InterestStockEntity> findByMemberId(Long memberId);
 
+    List<InterestStockEntity> findByStockInfoId(Long stockInfoId);
 }

--- a/src/main/java/com/flab/mars/db/repository/PriceDataRepository.java
+++ b/src/main/java/com/flab/mars/db/repository/PriceDataRepository.java
@@ -2,7 +2,10 @@ package com.flab.mars.db.repository;
 
 import com.flab.mars.db.entity.PriceDataEntity;
 import com.flab.mars.db.entity.StockInfoEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -12,5 +15,10 @@ public interface PriceDataRepository extends JpaRepository<PriceDataEntity, Long
     Optional<PriceDataEntity> findByStockInfoEntityAndDateTime(StockInfoEntity stockInfoEntity, LocalDateTime dateTime);
 
     Optional<PriceDataEntity> findTopByStockInfoEntityIdAndDateTimeAfterOrderByDateTimeDesc(Long stockInfoEntityId, LocalDateTime dateTimeAfter);
+
+    // 변동률이 5 이상인 PriceData 가져오기
+    @Query("select distinct p.stockInfoEntity.id from PriceDataEntity p where p.priceChangeRate >= :priceChangeRate")
+    Page<Long> findDistinctStockInfoIdsByPriceChangeRateGreaterThanEqual(Double priceChangeRate, Pageable pageable);
+
 
 }

--- a/src/main/java/com/flab/mars/db/repository/PriceDataRepository.java
+++ b/src/main/java/com/flab/mars/db/repository/PriceDataRepository.java
@@ -20,5 +20,7 @@ public interface PriceDataRepository extends JpaRepository<PriceDataEntity, Long
     @Query("select distinct p.stockInfoEntity.id from PriceDataEntity p where p.priceChangeRate >= :priceChangeRate")
     Page<Long> findDistinctStockInfoIdsByPriceChangeRateGreaterThanEqual(Double priceChangeRate, Pageable pageable);
 
+    Optional<PriceDataEntity> findTopByStockInfoEntityIdOrderByDateTimeDesc(Long stockInfoEntityId);
+
 
 }

--- a/src/main/java/com/flab/mars/domain/component/FirebaseMessageSender.java
+++ b/src/main/java/com/flab/mars/domain/component/FirebaseMessageSender.java
@@ -13,7 +13,7 @@ public class FirebaseMessageSender {
 
     private final FirebaseMessaging firebaseMessaging;
 
-    public Message makeMessage(String targetToken, String title, String body) {
+    private Message makeMessage(String targetToken, String title, String body) {
         Notification notification = Notification
                 .builder()
                 .setTitle(title)

--- a/src/main/java/com/flab/mars/domain/component/FirebaseMessageSender.java
+++ b/src/main/java/com/flab/mars/domain/component/FirebaseMessageSender.java
@@ -1,0 +1,36 @@
+package com.flab.mars.domain.component;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.Notification;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class FirebaseMessageSender {
+
+    private final FirebaseMessaging firebaseMessaging;
+
+    public static Message makeMessage(String targetToken, String title, String body) {
+        Notification notification = Notification
+                .builder()
+                .setTitle(title)
+                .setBody(body)
+                .build();
+        return Message
+                .builder()
+                .setNotification(notification)
+                .setToken(targetToken)
+                .build();
+    }
+
+    public void sendPush(String token, String title, String body) {
+        try {
+            firebaseMessaging.send(makeMessage(token, title, body));
+        } catch (FirebaseMessagingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/flab/mars/domain/component/FirebaseMessageSender.java
+++ b/src/main/java/com/flab/mars/domain/component/FirebaseMessageSender.java
@@ -13,7 +13,7 @@ public class FirebaseMessageSender {
 
     private final FirebaseMessaging firebaseMessaging;
 
-    public static Message makeMessage(String targetToken, String title, String body) {
+    public Message makeMessage(String targetToken, String title, String body) {
         Notification notification = Notification
                 .builder()
                 .setTitle(title)

--- a/src/main/java/com/flab/mars/domain/service/InterestStockService.java
+++ b/src/main/java/com/flab/mars/domain/service/InterestStockService.java
@@ -76,7 +76,7 @@ public class InterestStockService {
                     .currentPrice(latestPriceData != null ? latestPriceData.getCurrentPrice() : "0")
                     .priceChangeSign(latestPriceData != null ? latestPriceData.getPriceChangeSign() : "")
                     .priceChange(latestPriceData != null ? latestPriceData.getPriceChange() : "")
-                    .priceChangeRate(latestPriceData != null ? latestPriceData.getPriceChangeRate() : "0")
+                    .priceChangeRate(latestPriceData != null ? latestPriceData.getPriceChangeRate() : 0.0)
                     .build();
 
             interestStockVOs.add(interestStockVO);

--- a/src/main/java/com/flab/mars/domain/service/StockPriceFetcher.java
+++ b/src/main/java/com/flab/mars/domain/service/StockPriceFetcher.java
@@ -1,0 +1,32 @@
+package com.flab.mars.domain.service;
+
+import com.flab.mars.db.repository.PriceDataRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+@Component
+@RequiredArgsConstructor
+public class StockPriceFetcher {
+    private static final int PAGE_SIZE = 20;
+    private final PriceDataRepository priceDataRepository;
+
+    // 변동률 5 이상인 주식들 가져오기
+    public Stream<Long> fetchPagedStockIdWithHighChangeRate(Double priceChangeRate) {
+        return Stream.iterate(0, page -> page + 1) // 페이지 번호를 0 부터 하나씩 증가시킴
+                .map(page -> {
+                    Pageable pageable = PageRequest.of(page, PAGE_SIZE);
+                    Page<Long> stockIds = priceDataRepository.findDistinctStockInfoIdsByPriceChangeRateGreaterThanEqual(priceChangeRate, pageable);
+                    return (stockIds != null && stockIds.hasContent())
+                            ? stockIds.getContent()
+                            : List.<Long>of(); // null이면 빈 리스트 반환
+                })
+                .takeWhile(stockIds -> stockIds != null && !stockIds.isEmpty())// 데이터가 비어있지 않으면 계속 반복, 비면 종료
+                .flatMap(List::stream);
+    }
+}

--- a/src/main/java/com/flab/mars/domain/service/StockPriceFetcher.java
+++ b/src/main/java/com/flab/mars/domain/service/StockPriceFetcher.java
@@ -1,5 +1,6 @@
 package com.flab.mars.domain.service;
 
+import com.flab.mars.db.entity.PriceDataEntity;
 import com.flab.mars.db.repository.PriceDataRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -28,5 +29,11 @@ public class StockPriceFetcher {
                 })
                 .takeWhile(stockIds -> stockIds != null && !stockIds.isEmpty())// 데이터가 비어있지 않으면 계속 반복, 비면 종료
                 .flatMap(List::stream);
+    }
+
+    public Double getLatestPriceChageRateForStock(Long stockId) {
+        return priceDataRepository.findTopByStockInfoEntityIdOrderByDateTimeDesc(stockId)
+                .map(PriceDataEntity::getPriceChangeRate)
+                .orElse(null);
     }
 }

--- a/src/main/java/com/flab/mars/domain/service/StockPriceNotificationService.java
+++ b/src/main/java/com/flab/mars/domain/service/StockPriceNotificationService.java
@@ -48,12 +48,12 @@ public class StockPriceNotificationService {
             interestStockEntities.forEach(interestStock -> {
                 // 해당 정보를 기반으로 memberid 에게 문자 보내기
                 Long memberId = interestStock.getMemberId();
-                memberRepository.findById(memberId).ifPresent(member -> SendNotification(stockId, interestStock, member));
+                memberRepository.findById(memberId).ifPresent(member -> sendNotification(stockId, interestStock, member));
             });
         });
     }
 
-    private void SendNotification(Long stockId, InterestStockEntity interestStock, MemberEntity member) {
+    private void sendNotification(Long stockId, InterestStockEntity interestStock, MemberEntity member) {
         String fcmToken = member.getFCMToken();
         if (!StringUtils.hasText(fcmToken)) {
             log.info("memberId : {} , fcm token is creating : {}", member.getId(), fcmToken);

--- a/src/main/java/com/flab/mars/domain/service/StockPriceNotificationService.java
+++ b/src/main/java/com/flab/mars/domain/service/StockPriceNotificationService.java
@@ -1,0 +1,37 @@
+package com.flab.mars.domain.service;
+
+import com.flab.mars.db.entity.InterestStockEntity;
+import com.flab.mars.db.repository.InterestStockRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+// DB 에 +-5% 값을 가지는 stockid 를 가져와서
+// 해당 interrst 에 stockid 기반으로 member 를 가져오고
+// 해당 정보를 기반으로 memberid 에게 문자 보내기
+@Service
+@RequiredArgsConstructor
+public class StockPriceNotificationService {
+
+    private final StockPriceFetcher stockPriceFetcher;
+
+    private final InterestStockRepository interestStockRepository;
+
+    private final double CHANGE_RATE = 5.0;
+
+    public void notifyStockPrice() {
+        Stream<Long> priceDataEntityStream = stockPriceFetcher.fetchPagedStockIdWithHighChangeRate(CHANGE_RATE);
+        priceDataEntityStream.forEach(stockId -> {
+            List<InterestStockEntity> interestStockEntities = interestStockRepository.findByStockInfoId(stockId);
+            // 관심 주식을 가진 사용자들에게 문자 전송
+            interestStockEntities.forEach(interestStock -> {
+                // TODO
+                Long memberId = interestStock.getMemberId();
+
+            });
+
+        });
+    }
+}

--- a/src/main/java/com/flab/mars/domain/service/StockPriceNotificationService.java
+++ b/src/main/java/com/flab/mars/domain/service/StockPriceNotificationService.java
@@ -1,37 +1,77 @@
 package com.flab.mars.domain.service;
 
 import com.flab.mars.db.entity.InterestStockEntity;
+import com.flab.mars.db.entity.MemberEntity;
 import com.flab.mars.db.repository.InterestStockRepository;
+import com.flab.mars.db.repository.MemberRepository;
+import com.flab.mars.domain.component.FirebaseMessageSender;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 import java.util.List;
 import java.util.stream.Stream;
 
-// DB 에 +-5% 값을 가지는 stockid 를 가져와서
-// 해당 interrst 에 stockid 기반으로 member 를 가져오고
-// 해당 정보를 기반으로 memberid 에게 문자 보내기
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class StockPriceNotificationService {
 
     private final StockPriceFetcher stockPriceFetcher;
 
     private final InterestStockRepository interestStockRepository;
 
+    private final MemberRepository memberRepository;
+
+    private final FirebaseMessageSender firebaseMessageSender;
+
     private final double CHANGE_RATE = 5.0;
 
+    @Value("${notification.stock.title}")
+    private String titleTemplate;
+
+    @Value("${notification.stock.message}")
+    private String messageTemplate;
+
+    @Transactional(readOnly = true) //  @Transactional을 사용하여 세션 유지
     public void notifyStockPrice() {
+        // DB 에 +-5% 값을 가지는 stockid 를 가져와서
         Stream<Long> priceDataEntityStream = stockPriceFetcher.fetchPagedStockIdWithHighChangeRate(CHANGE_RATE);
+
+        // stockid 기반으로 member 를 가져오고
         priceDataEntityStream.forEach(stockId -> {
             List<InterestStockEntity> interestStockEntities = interestStockRepository.findByStockInfoId(stockId);
             // 관심 주식을 가진 사용자들에게 문자 전송
             interestStockEntities.forEach(interestStock -> {
-                // TODO
+                // 해당 정보를 기반으로 memberid 에게 문자 보내기
                 Long memberId = interestStock.getMemberId();
-
+                memberRepository.findById(memberId).ifPresent(member -> SendNotification(stockId, interestStock, member));
             });
-
         });
+    }
+
+    private void SendNotification(Long stockId, InterestStockEntity interestStock, MemberEntity member) {
+        String fcmToken = member.getFCMToken();
+        if (!StringUtils.hasText(fcmToken)) {
+            log.info("memberId : {} , fcm token is creating : {}", member.getId(), fcmToken);
+            return;
+        }
+
+        // 주식 가격 변동률 가져오기
+        Double changeRate = stockPriceFetcher.getLatestPriceChageRateForStock(stockId);
+        String message = String.format(messageTemplate, changeRate);
+
+        // Could not initialize proxy 발생 -  no session  =>   @Transactional 으로 해결
+        String notificationMessage = String.format("%s %s", interestStock.getStockInfo().getStockName(), message);
+
+        try {
+            firebaseMessageSender.sendPush(fcmToken, titleTemplate, notificationMessage);
+            log.info("memberId : {}, message: {} 알림 전송", member.getId(), notificationMessage);
+        } catch (Exception e) {
+            log.error("memberId: {}, 알림 전송 실패: {}", member.getId(), e.getMessage(), e);
+        }
     }
 }

--- a/src/main/java/com/flab/mars/domain/service/StockPriceNotificationService.java
+++ b/src/main/java/com/flab/mars/domain/service/StockPriceNotificationService.java
@@ -9,7 +9,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
 import java.util.List;
@@ -36,7 +35,6 @@ public class StockPriceNotificationService {
     @Value("${notification.stock.message}")
     private String messageTemplate;
 
-    @Transactional(readOnly = true) //  @Transactional을 사용하여 세션 유지
     public void notifyStockPrice() {
         // DB 에 +-5% 값을 가지는 stockid 를 가져와서
         Stream<Long> priceDataEntityStream = stockPriceFetcher.fetchPagedStockIdWithHighChangeRate(CHANGE_RATE);
@@ -48,15 +46,15 @@ public class StockPriceNotificationService {
             interestStockEntities.forEach(interestStock -> {
                 // 해당 정보를 기반으로 memberid 에게 문자 보내기
                 Long memberId = interestStock.getMemberId();
-                memberRepository.findById(memberId).ifPresent(member -> sendNotification(stockId, interestStock, member));
+                memberRepository.findById(memberId).ifPresent(member -> sendNotification(stockId, interestStock.getStockInfo().getStockName(), member));
             });
         });
     }
 
-    private void sendNotification(Long stockId, InterestStockEntity interestStock, MemberEntity member) {
+    private void sendNotification(Long stockId, String stockName, MemberEntity member) {
         String fcmToken = member.getFCMToken();
         if (!StringUtils.hasText(fcmToken)) {
-            log.info("memberId : {} , fcm token is creating : {}", member.getId(), fcmToken);
+            log.info("memberId : {} , fcm token is empty : {}", member.getId(), fcmToken);
             return;
         }
 
@@ -64,8 +62,7 @@ public class StockPriceNotificationService {
         Double changeRate = stockPriceFetcher.getLatestPriceChageRateForStock(stockId);
         String message = String.format(messageTemplate, changeRate);
 
-        // Could not initialize proxy 발생 -  no session  =>   @Transactional 으로 해결
-        String notificationMessage = String.format("%s %s", interestStock.getStockInfo().getStockName(), message);
+        String notificationMessage = String.format("%s %s", stockName, message);
 
         try {
             firebaseMessageSender.sendPush(fcmToken, titleTemplate, notificationMessage);

--- a/src/main/java/com/flab/mars/domain/vo/response/InterestStockVO.java
+++ b/src/main/java/com/flab/mars/domain/vo/response/InterestStockVO.java
@@ -16,5 +16,5 @@ public class InterestStockVO {
     private String currentPrice;    // 현재가
     private String priceChange;        // 전일 대비
     private String priceChangeSign;    // 전일 대비 부호
-    private String priceChangeRate; // 전일 대비율
+    private Double priceChangeRate; // 전일 대비율
 }

--- a/src/main/java/com/flab/mars/scheduler/StockPriceNotificationScheduler.java
+++ b/src/main/java/com/flab/mars/scheduler/StockPriceNotificationScheduler.java
@@ -1,0 +1,27 @@
+package com.flab.mars.scheduler;
+
+import com.flab.mars.domain.service.StockPriceNotificationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class StockPriceNotificationScheduler {
+
+    private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+    private final StockPriceNotificationService stockPriceNotificationService;
+
+    // +-5%를 기준으로 알림 보내기
+    @Scheduled(fixedRate = 600000) // 10분주기
+    public void sendPriceChangeNotification() {
+        log.info("StockPriceNotificationScheduler started at {}", LocalDateTime.now().format(formatter));
+        stockPriceNotificationService.notifyStockPrice();
+        log.info("StockPriceNotificationScheduler completed at {}", LocalDateTime.now().format(formatter));
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,3 +30,13 @@ kis:
     app_key: PSvmItgnWGaKewHlPjtS37dBrne7NXFWPfVF
     app_secret: YaLtdbOxGxzrztwLGbPoXo/c+X892jML3ucRYDELTQ/MbQRXbS2qcyjh6rhyCKSlh9NQ3bBXGXQEZE3nMivPsFe8lLgDqAlmfuHQlYnbB9F3l1GoeLMG/C/sy4vzfd8OxUXf+u2CAG/UOaJEcH7TtQ8xSZ6tE6St4uM4Oon2ooFm6so0epc=
     access_token : eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0b2tlbiIsImF1ZCI6IjU2N2Y4NDZmLTE1YTgtNDdmNy1iOWIyLWExY2Q3YTNlMTY3YyIsInByZHRfY2QiOiIiLCJpc3MiOiJ1bm9ndyIsImV4cCI6MTc0MTQxNTMxNSwiaWF0IjoxNzQxMzI4OTE1LCJqdGkiOiJQU3ZtSXRnbldHYUtld0hsUGp0UzM3ZEJybmU3TlhGV1BmVkYifQ.O5Q4481YyHv5NlAr45V7CQ7bNdm3IO5hx7YEw7UMWNmbOsQNbGGSeZOE5DXLlJRel7ZrUBtHS91P_C9yE_PRYA
+
+firebase:
+  credentials:
+    path: firebase/mars-1a3f5-firebase-adminsdk-fbsvc-db14567537.json
+
+notification:
+  stock:
+    title: "📈 주식 변동 알림"
+    message: "변동률은 %.2f%% 이상 변동하였습니다."
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,9 +27,9 @@ logging:
 kis:
   api:
     grant_type: client_credentials
-    app_key: PSvmItgnWGaKewHlPjtS37dBrne7NXFWPfVF
-    app_secret: YaLtdbOxGxzrztwLGbPoXo/c+X892jML3ucRYDELTQ/MbQRXbS2qcyjh6rhyCKSlh9NQ3bBXGXQEZE3nMivPsFe8lLgDqAlmfuHQlYnbB9F3l1GoeLMG/C/sy4vzfd8OxUXf+u2CAG/UOaJEcH7TtQ8xSZ6tE6St4uM4Oon2ooFm6so0epc=
-    access_token : eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0b2tlbiIsImF1ZCI6IjU2N2Y4NDZmLTE1YTgtNDdmNy1iOWIyLWExY2Q3YTNlMTY3YyIsInByZHRfY2QiOiIiLCJpc3MiOiJ1bm9ndyIsImV4cCI6MTc0MTQxNTMxNSwiaWF0IjoxNzQxMzI4OTE1LCJqdGkiOiJQU3ZtSXRnbldHYUtld0hsUGp0UzM3ZEJybmU3TlhGV1BmVkYifQ.O5Q4481YyHv5NlAr45V7CQ7bNdm3IO5hx7YEw7UMWNmbOsQNbGGSeZOE5DXLlJRel7ZrUBtHS91P_C9yE_PRYA
+    app_key: app_key
+    app_secret: app_secret
+    access_token : access_token
 
 firebase:
   credentials:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,6 +27,6 @@ logging:
 kis:
   api:
     grant_type: client_credentials
-    app_key: app_key
-    app_secret: app_secret
-    access_token : access_token
+    app_key: PSvmItgnWGaKewHlPjtS37dBrne7NXFWPfVF
+    app_secret: YaLtdbOxGxzrztwLGbPoXo/c+X892jML3ucRYDELTQ/MbQRXbS2qcyjh6rhyCKSlh9NQ3bBXGXQEZE3nMivPsFe8lLgDqAlmfuHQlYnbB9F3l1GoeLMG/C/sy4vzfd8OxUXf+u2CAG/UOaJEcH7TtQ8xSZ6tE6St4uM4Oon2ooFm6so0epc=
+    access_token : eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0b2tlbiIsImF1ZCI6IjU2N2Y4NDZmLTE1YTgtNDdmNy1iOWIyLWExY2Q3YTNlMTY3YyIsInByZHRfY2QiOiIiLCJpc3MiOiJ1bm9ndyIsImV4cCI6MTc0MTQxNTMxNSwiaWF0IjoxNzQxMzI4OTE1LCJqdGkiOiJQU3ZtSXRnbldHYUtld0hsUGp0UzM3ZEJybmU3TlhGV1BmVkYifQ.O5Q4481YyHv5NlAr45V7CQ7bNdm3IO5hx7YEw7UMWNmbOsQNbGGSeZOE5DXLlJRel7ZrUBtHS91P_C9yE_PRYA

--- a/src/main/resources/static/firebase-messaging-sw.js
+++ b/src/main/resources/static/firebase-messaging-sw.js
@@ -1,0 +1,20 @@
+// firebase-messaging-sw.js 서비스워커는 백그라운드에서 실행되는 스크립트로,
+// 서비스를 실행하지 않거나 브라우저가 닫혔을 때 등에도 푸시 알림을 받을 수 있도록 한다
+
+importScripts("https://www.gstatic.com/firebasejs/8.10.0/firebase-app.js");
+importScripts("https://www.gstatic.com/firebasejs/8.10.0/firebase-messaging.js");
+
+// Firebase 설정
+const firebaseConfig = {
+    apiKey: "YOUR_API_KEY",
+    authDomain: "YOUR_AUTH_DOMAIN",
+    projectId: "YOUR_PROJECT_ID",
+    storageBucket: "YOUR_STORAGE_BUCKET",
+    messagingSenderId: "YOUR_MESSAGING_SENDER_ID",
+    appId: "YOUR_APP_ID",
+    measurementId: "YOUR_MEASUREMENT_ID"
+};
+
+// Firebase 앱 초기화
+const app = firebase.initializeApp(firebaseConfig);
+const messaging = firebase.messaging();

--- a/src/main/resources/templates/fcmtoken.html
+++ b/src/main/resources/templates/fcmtoken.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>FCM Token Loader</title>
+    <!-- Firebase SDK -->
+    <script src="https://www.gstatic.com/firebasejs/8.10.0/firebase.js"></script>
+    <script type="module" src="https://www.gstatic.com/firebasejs/8.10.0/firebase-app.js"></script>
+    <script type="module" src="https://www.gstatic.com/firebasejs/8.10.0/firebase-messaging.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/sockjs-client/1.5.1/sockjs.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/stomp.js/2.3.3/stomp.min.js"></script>
+</head>
+<body>
+
+<h1>FCM Token 생성</h1>
+<button id="get-token">FCM 토큰 요청</button>
+
+<script type="module">
+    // Firebase 설정 및 초기화 코드
+    const firebaseConfig = {
+        apiKey: "YOUR_API_KEY",
+        authDomain: "YOUR_AUTH_DOMAIN",
+        projectId: "YOUR_PROJECT_ID",
+        storageBucket: "YOUR_STORAGE_BUCKET",
+        messagingSenderId: "YOUR_MESSAGING_SENDER_ID",
+        appId: "YOUR_APP_ID",
+        measurementId: "YOUR_MEASUREMENT_ID"
+    };
+
+    // Firebase 앱 초기화
+    firebase.initializeApp(firebaseConfig);
+
+    // Firebase Messaging 초기화
+    const messaging = firebase.messaging();
+
+    // 서비스 워커 등록 (firebase-messaging-sw.js)
+    if ('serviceWorker' in navigator) {
+        navigator.serviceWorker.register('/firebase-messaging-sw.js')
+            .then(function(registration) {
+                console.log('서비스 워커 등록 성공:', registration);
+            })
+            .catch(function(error) {
+                console.error('서비스 워커 등록 실패:', error);
+            });
+    }
+
+
+    const enableNotificationsButton = document.getElementById('get-token');
+    enableNotificationsButton.addEventListener('click', () => {
+        Notification.requestPermission().then((permission) => {
+            if (permission === 'granted') {
+                messaging.getToken({  vapidKey: "vapidKey" })
+                    .then((tokenValue) => {
+                        console.log(`푸시 토큰 발급 완료 : ${tokenValue}`)
+                    })
+                    .catch((err) => {
+                        console.log('푸시 토큰 가져오는 중에 에러 발생')
+                    })
+            } else {
+                console.log('푸시 알림 거부됨');
+            }
+        })
+            .catch((error) => {
+                console.error('Firebase 토큰 가져오기 실패:', error);
+            });
+    });
+</script>
+
+</body>
+</html>

--- a/src/test/java/com/flab/mars/domain/service/StockPriceSaverTest.java
+++ b/src/test/java/com/flab/mars/domain/service/StockPriceSaverTest.java
@@ -42,7 +42,7 @@ class StockPriceSaverTest {
         stockPriceDetails.setAccumulatedTradeAmount("2000000");
         stockPriceDetails.setPriceChange("50");
         stockPriceDetails.setPriceChangeSign("+");
-        stockPriceDetails.setPriceChangeRate("5.0");
+        stockPriceDetails.setPriceChangeRate(5.0);
         kisStockPriceDto.setStockPriceDetails(stockPriceDetails);
 
         stockInfoEntity = StockInfoEntity.builder()


### PR DESCRIPTION
# feat: 관심 주식 5% 이상 변동 시 FCM 알림 기능 추가  

## 개요  
관심 주식의 가격이 5% 이상 변동할 경우, FCM을 통해 푸시 알림을 받을 수 있도록 프론트엔드 및 백엔드 기능을 추가했습니다.  

## 주요 변경 사항  

### 프론트엔드  
- Firebase SDK를 이용한 FCM 초기화  
- 디바이스별로 발급되는  FCM 디바이스 토큰 발급 기능 추가  
- `firebase-messaging-sw.js` 서비스 워커 등록 
   - FCM 푸시 알림을 처리하기 위한 서비스 워커 등록
   - 백그라운드에서 푸시 알림을 수신하고 처리하는 역할
- 버튼 클릭 시 FCM 토큰을 콘솔에 출력 (추후 서버에 저장 필요)  

### 백엔드  
- `StockPriceNotificationScheduler` 를 통해 10분 주기로 관심 주식의 가격 변동률을 확인  
- `StockPriceNotificationService` 에서  
  - 관심 주식의 최신 변동률을 조회  
  - 변동률이 5% 이상이면 해당 주식을 관심 종목으로 등록한 회원 조회  
  - 회원의 FCM 토큰을 가져와 푸시 알림 전송  
- `@Transactional(readOnly = true)` 를 적용하여 Lazy Loading 문제 해결  

## 테스트 방법  

### 프론트엔드  
1.  `firebaseConfig` 에 FCM 관련 설정값을 추가합니다.  
2. 로컬 서버에서 해당 페이지(http://127.0.0.1:8080/api/fcmtoken)를 실행합니다.  
3. "FCM 토큰 요청" 버튼을 클릭하여 브라우저 알림 권한을 허용합니다.  
4. 콘솔에서 발급된 FCM 토큰을 확인합니다.  

### 백엔드  
1. 관심 주식을 등록한 회원을 DB에 추가합니다.  
2. 일정 주기마다 `StockPriceNotificationScheduler` 가 실행되는지 확인합니다.  
3. 변동률이 5% 이상인 주식에 대해 알림이 정상적으로 전송되는지 로그 및 FCM 콘솔에서 확인합니다.  
 
